### PR TITLE
Code-corrections and cosmetic changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JetBrains
+.idea/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2015-10-28 Laurens Stötzel <l.stoetzel@meeva.de>
+2015-10-28 Laurens StÃ¶tzel <l.stoetzel@meeva.de>
     * Use default Typo3 link handling (support link parameters)
 
 2014-02-06 Robert Heel <typo3@bobosch.de>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-10-28 Laurens Stötzel <l.stoetzel@meeva.de>
+    * Use default Typo3 link handling (support link parameters)
+
 2014-02-06 Robert Heel <typo3@bobosch.de>
 	* Add: Regex redirect mode.
 	* Add: Index on column mode to ensure the database engine process this column first.

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -26,7 +26,7 @@ class ext_update
 {
     function main()
     {
-        $GLOBALS['TYPO3_DB']->sql_query(
+     $GLOBALS['TYPO3_DB']->sql_query(
             'REPLACE INTO tx_odsredirects_redirects(mode,url,destination,last_referer,counter,tstamp,has_moved) SELECT 1,url,destination,last_referer,counter,tstamp,has_moved FROM tx_realurl_redirects'
         );
         $content = 'Imported realurl redirect table.';

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,40 +1,45 @@
 <?php
+
 /***************************************************************
-*  Copyright notice
-*
-*  (c) 2010 Robert Heel (rheel@1drop.de)
-*  All rights reserved
-*
-*  This script is part of the Typo3 project. The Typo3 project is
-*  free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2 of the License, or
-*  (at your option) any later version.
-*
-*  The GNU General Public License can be found at
-*  http://www.gnu.org/copyleft/gpl.html.
-*
-*  This script is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  This copyright notice MUST APPEAR in all copies of the script!
-***************************************************************/
+ *  Copyright notice
+ *
+ *  (c) 2010 Robert Heel (rheel@1drop.de)
+ *  All rights reserved
+ *
+ *  This script is part of the Typo3 project. The Typo3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+class ext_update
+{
+    function main()
+    {
+        $GLOBALS['TYPO3_DB']->sql_query(
+            'REPLACE INTO tx_odsredirects_redirects(mode,url,destination,last_referer,counter,tstamp,has_moved) SELECT 1,url,destination,last_referer,counter,tstamp,has_moved FROM tx_realurl_redirects'
+        );
+        $content = 'Imported realurl redirect table.';
 
-class ext_update {
-	function main(){
-		$GLOBALS['TYPO3_DB']->sql_query('REPLACE INTO tx_odsredirects_redirects(mode,url,destination,last_referer,counter,tstamp,has_moved) SELECT 1,url,destination,last_referer,counter,tstamp,has_moved FROM tx_realurl_redirects');
-		$content='Imported realurl redirect table.';
-		return $content;
-	}
+        return $content;
+    }
 
-	function access(){
-		return true;
-	}
+    function access()
+    {
+        return true;
+    }
 }
 
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.ext_update.php'])	{
-	include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.ext_update.php']);
+if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.ext_update.php']) {
+    include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.ext_update.php']);
 }
-?>

--- a/class.tx_odsredirects.php
+++ b/class.tx_odsredirects.php
@@ -2,187 +2,187 @@
 
 class tx_odsredirects
 {
-	function checkRedirect(&$params)
-	{
-		$pObj = $params['pObj'];
-		/*
-			Priority (highest on top):
-			mode 2: Path and query string match
-			mode 3: Path and only given query parts match
-			mode 1: Path match
-			mode 0: Begins with path
-			mode 4: Path and query string regex match
-		*/
-		$prio = array('0' => 50, '1' => 100, '2' => 200, '3' => 150, '4' => 10);
+    function checkRedirect(&$params)
+    {
+        $pObj = $params['pObj'];
+        /*
+            Priority (highest on top):
+            mode 2: Path and query string match
+            mode 3: Path and only given query parts match
+            mode 1: Path match
+            mode 0: Begins with path
+            mode 4: Path and query string regex match
+        */
+        $prio = array('0' => 50, '1' => 100, '2' => 200, '3' => 150, '4' => 10);
 
-		// URL parts
-		$url = $pObj->siteScript;
-		$path = strtok($pObj->siteScript, '?');
+        // URL parts
+        $url = $pObj->siteScript;
+        $path = strtok($pObj->siteScript, '?');
 
-		// Create query
-		$where = array(
-			'(mode=0 AND url=LEFT(' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
-				$url,
-				'tx_odsredirects_redirects'
-			) . ',LENGTH(url)))',
-			// Begins with URL
-			'(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($path, 'tx_odsredirects_redirects') . ')',
-			// Path match
-			'(mode=2 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ')',
-			// Path and query string match
-			'(mode=4 AND ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ' REGEXP url)',
-			// Path and query string regex match
-		);
+        // Create query
+        $where = array(
+            '(mode=0 AND url=LEFT(' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                $url,
+                'tx_odsredirects_redirects'
+            ) . ',LENGTH(url)))',
+            // Begins with URL
+            '(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($path, 'tx_odsredirects_redirects') . ')',
+            // Path match
+            '(mode=2 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ')',
+            // Path and query string match
+            '(mode=4 AND ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ' REGEXP url)',
+            // Path and query string regex match
+        );
 
-		// Path match if entered without trailing '/'
-		if (substr($path, -1) != '/') {
-			$where[] = '(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
-					$path . '/',
-					'tx_odsredirects_redirects'
-				) . ')';
-		}
+        // Path match if entered without trailing '/'
+        if (substr($path, -1) != '/') {
+            $where[] = '(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                    $path . '/',
+                    'tx_odsredirects_redirects'
+                ) . ')';
+        }
 
-		// Fetch redirects
-		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'*',
-			'tx_odsredirects_redirects',
-			'(' . implode(' OR ', $where) . ') AND hidden=0',
-			'',
-			'domain_id DESC'
-		);
-		$redirect = false;
-		while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-			// Check further requirements
+        // Fetch redirects
+        $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            '*',
+            'tx_odsredirects_redirects',
+            '(' . implode(' OR ', $where) . ') AND hidden=0',
+            '',
+            'domain_id DESC'
+        );
+        $redirect = false;
+        while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+            // Check further requirements
 
-			if ($row) {
-				// Entries with a domain_id have priority
-				if ($row['domain_id']) {
-					if (!$domain_id) {
-						// Get domain record
-						$res2 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-							'uid',
-							'sys_domain',
-							'domainName=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
-								$_SERVER['HTTP_HOST'],
-								'sys_domain'
-							) . ' AND hidden=0'
-						);
-						$row2 = $GLOBALS['TYPO3_DB']->sql_fetch_row($res2);
-						$domain_id = $row2[0];
-					}
-					if ($row['domain_id'] == $domain_id) {
-						$specific = true;
-						if ($prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
-					}
-				} else {
-					// All Domains
-					if (!$specific && $prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
-				}
-			}
-		}
+            if ($row) {
+                // Entries with a domain_id have priority
+                if ($row['domain_id']) {
+                    if (!$domain_id) {
+                        // Get domain record
+                        $res2 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                            'uid',
+                            'sys_domain',
+                            'domainName=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                                $_SERVER['HTTP_HOST'],
+                                'sys_domain'
+                            ) . ' AND hidden=0'
+                        );
+                        $row2 = $GLOBALS['TYPO3_DB']->sql_fetch_row($res2);
+                        $domain_id = $row2[0];
+                    }
+                    if ($row['domain_id'] == $domain_id) {
+                        $specific = true;
+                        if ($prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
+                    }
+                } else {
+                    // All Domains
+                    if (!$specific && $prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
+                }
+            }
+        }
 
-		// Do redirect
-		if ($redirect) {
-			// Update statistics
-			$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-				'tx_odsredirects_redirects',
-				'uid=' . $redirect['uid'],
-				array(
-					'counter' => 'counter+1',
-					'tstamp' => time(),
-					'last_referer' => t3lib_div::getIndpEnv('HTTP_REFERER'),
-				),
-				array('counter')
-			);
+        // Do redirect
+        if ($redirect) {
+            // Update statistics
+            $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+                'tx_odsredirects_redirects',
+                'uid=' . $redirect['uid'],
+                array(
+                    'counter' => 'counter+1',
+                    'tstamp' => time(),
+                    'last_referer' => t3lib_div::getIndpEnv('HTTP_REFERER'),
+                ),
+                array('counter')
+            );
 
-			// Build destination URL
-			if ($redirect['mode'] == 4) $redirect['destination'] =
-				preg_replace('/' . $redirect['url'] . '/i', $redirect['destination'], $url);
-			$destination = $this->getLink($redirect['destination'], $_SERVER['HTTP_HOST'] . '/' . $url);
+            // Build destination URL
+            if ($redirect['mode'] == 4) $redirect['destination'] =
+                preg_replace('/' . $redirect['url'] . '/i', $redirect['destination'], $url);
+            $destination = $this->getLink($redirect['destination'], $_SERVER['HTTP_HOST'] . '/' . $url);
 
-			// Append trailing url
-			if ($redirect['append']) {
-				$append = substr($url, strlen($redirect['url']));
-				// Replace ? by & if query parts appended to non speaking url
-				if (strpos($destination, '?') && substr($append, 0, 1) == '?') $append = '&' . substr($append, 1);
-				$destination .= $append;
-			}
+            // Append trailing url
+            if ($redirect['append']) {
+                $append = substr($url, strlen($redirect['url']));
+                // Replace ? by & if query parts appended to non speaking url
+                if (strpos($destination, '?') && substr($append, 0, 1) == '?') $append = '&' . substr($append, 1);
+                $destination .= $append;
+            }
 
-			// Redirect
-			if ($redirect['has_moved']) {
-				header('HTTP/1.1 301 Moved Permanently');
-			}
-			header('Location: ' . t3lib_div::locationHeaderUrl($destination));
-			header('X-Note: Redirect by ods_redirects');
-			header('Connection: close');
-			exit();
-		}
-	}
+            // Redirect
+            if ($redirect['has_moved']) {
+                header('HTTP/1.1 301 Moved Permanently');
+            }
+            header('Location: ' . t3lib_div::locationHeaderUrl($destination));
+            header('X-Note: Redirect by ods_redirects');
+            header('Connection: close');
+            exit();
+        }
+    }
 
-	/**
-	 * @param string $destination
-	 * @param string $source
-	 * @return string
+    /**
+     * @param string $destination
+     * @param string $source
+     * @return string
      */
-	function getLink($destination, $source = '')
-	{
-		$L = $this->languageDetection($source);
+    function getLink($destination, $source = '')
+    {
+        $L = $this->languageDetection($source);
 
-		return $this->buildURL($destination, $L ? array('L' => $L) : array());
-	}
+        return $this->buildURL($destination, $L ? array('L' => $L) : array());
+    }
 
-	/**
-	 * @param string $source
-	 * @return bool|int
+    /**
+     * @param string $source
+     * @return bool|int
      */
-	function languageDetection($source)
-	{
-		$conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ods_redirects']);
+    function languageDetection($source)
+    {
+        $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ods_redirects']);
 
-		// Language from L
-		$L = is_numeric(t3lib_div::_GP('L')) ? intval(t3lib_div::_GP('L')) : false;
+        // Language from L
+        $L = is_numeric(t3lib_div::_GP('L')) ? intval(t3lib_div::_GP('L')) : false;
 
-		// Language from speaking URL
-		if (!$L && $conf['lang_detect'] && $source) {
-			$lang_detect = array();
-			foreach (explode(';', $conf['lang_detect']) as $pair) {
-				$parts = explode('=', $pair);
-				$lang_detect[$parts[0]] = $parts[1];
-			}
-			foreach ($lang_detect as $str => $id) {
-				if (strpos($source, strval($str)) !== false) $L = intval($id);
-			}
-		}
+        // Language from speaking URL
+        if (!$L && $conf['lang_detect'] && $source) {
+            $lang_detect = array();
+            foreach (explode(';', $conf['lang_detect']) as $pair) {
+                $parts = explode('=', $pair);
+                $lang_detect[$parts[0]] = $parts[1];
+            }
+            foreach ($lang_detect as $str => $id) {
+                if (strpos($source, strval($str)) !== false) $L = intval($id);
+            }
+        }
 
-		return $L;
-	}
+        return $L;
+    }
 
-	/**
-	 * @param string $id
-	 * @param bool $L
-	 * @return string
+    /**
+     * @param string $id
+     * @param bool $L
+     * @return string
      */
-	function buildURL($id, $L = false)
-	{
-		if ($id) {
-			$GLOBALS['TSFE']->determineId();
-			$GLOBALS['TSFE']->getCompressedTCarray();
-			$GLOBALS['TSFE']->initTemplate();
-			$GLOBALS['TSFE']->getConfigArray();
+    function buildURL($id, $L = false)
+    {
+        if ($id) {
+            $GLOBALS['TSFE']->determineId();
+            $GLOBALS['TSFE']->getCompressedTCarray();
+            $GLOBALS['TSFE']->initTemplate();
+            $GLOBALS['TSFE']->getConfigArray();
 
-			// Set linkVars, absRefPrefix, etc
-			require_once(PATH_tslib . 'class.tslib_pagegen.php');
-			TSpagegen::pagegenInit();
+            // Set linkVars, absRefPrefix, etc
+            require_once(PATH_tslib . 'class.tslib_pagegen.php');
+            TSpagegen::pagegenInit();
 
-			$cObj = t3lib_div::makeInstance('tslib_cObj');
-			$cObj->start(array());
-			$url = $cObj->getTypoLink_URL($id, $L ? array('L' => $L) : array());
+            $cObj = t3lib_div::makeInstance('tslib_cObj');
+            $cObj->start(array());
+            $url = $cObj->getTypoLink_URL($id, $L ? array('L' => $L) : array());
 
-			return $url;
-		}
-	}
+            return $url;
+        }
+    }
 }
 
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php']) {
-	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php']);
+    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php']);
 }

--- a/class.tx_odsredirects.php
+++ b/class.tx_odsredirects.php
@@ -1,8 +1,10 @@
 <?php
-class tx_odsredirects {
-	function checkRedirect(&$params){
-		$pObj=$params['pObj'];
-//		$hash = t3lib_div::md5int($speakingURIpath);
+
+class tx_odsredirects
+{
+	function checkRedirect(&$params)
+	{
+		$pObj = $params['pObj'];
 		/*
 			Priority (highest on top):
 			mode 2: Path and query string match
@@ -11,155 +13,158 @@ class tx_odsredirects {
 			mode 0: Begins with path
 			mode 4: Path and query string regex match
 		*/
-		$prio=array('0'=>50,'1'=>100,'2'=>200,'3'=>150,'4'=>10);
+		$prio = array('0' => 50, '1' => 100, '2' => 200, '3' => 150, '4' => 10);
 
 		// URL parts
-		$url=$pObj->siteScript;
-		$path=strtok($pObj->siteScript,'?');
+		$url = $pObj->siteScript;
+		$path = strtok($pObj->siteScript, '?');
 
 		// Create query
-		$where=array(
-			'(mode=0 AND url=LEFT('.$GLOBALS['TYPO3_DB']->fullQuoteStr($url,'tx_odsredirects_redirects').',LENGTH(url)))', // Begins with URL
-			'(mode=1 AND url='.$GLOBALS['TYPO3_DB']->fullQuoteStr($path,'tx_odsredirects_redirects').')', // Path match
-			'(mode=2 AND url='.$GLOBALS['TYPO3_DB']->fullQuoteStr($url,'tx_odsredirects_redirects').')', // Path and query string match
-			'(mode=4 AND '.$GLOBALS['TYPO3_DB']->fullQuoteStr($url,'tx_odsredirects_redirects').' REGEXP url)', // Path and query string regex match
+		$where = array(
+			'(mode=0 AND url=LEFT(' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+				$url,
+				'tx_odsredirects_redirects'
+			) . ',LENGTH(url)))',
+			// Begins with URL
+			'(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($path, 'tx_odsredirects_redirects') . ')',
+			// Path match
+			'(mode=2 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ')',
+			// Path and query string match
+			'(mode=4 AND ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($url, 'tx_odsredirects_redirects') . ' REGEXP url)',
+			// Path and query string regex match
 		);
-		if(substr($path,-1)!='/') $where[]='(mode=1 AND url='.$GLOBALS['TYPO3_DB']->fullQuoteStr($path.'/','tx_odsredirects_redirects').')'; // Path match if entered without trailing '/'
+
+		// Path match if entered without trailing '/'
+		if (substr($path, -1) != '/') {
+			$where[] = '(mode=1 AND url=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+					$path . '/',
+					'tx_odsredirects_redirects'
+				) . ')';
+		}
 
 		// Fetch redirects
-		$res=$GLOBALS['TYPO3_DB']->exec_SELECTquery(
+		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 			'*',
 			'tx_odsredirects_redirects',
-			'('.implode(' OR ',$where).') AND hidden=0',
+			'(' . implode(' OR ', $where) . ') AND hidden=0',
 			'',
 			'domain_id DESC'
 		);
-		$redirect=false;
-		while($row=$GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)){
-			// Check furhter requirements
-/*			switch($row['mode']){
-				case '3':
-					// Only given query parts must match
-					$parts=parse_url($row['url']);
-					$parts=parse_url();
-				break;
-			}*/
+		$redirect = false;
+		while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+			// Check further requirements
 
-			if($row){
+			if ($row) {
 				// Entries with a domain_id have priority
-				if($row['domain_id']){
-					if(!$domain_id){
+				if ($row['domain_id']) {
+					if (!$domain_id) {
 						// Get domain record
-						$res2=$GLOBALS['TYPO3_DB']->exec_SELECTquery('uid','sys_domain','domainName='.$GLOBALS['TYPO3_DB']->fullQuoteStr($_SERVER['HTTP_HOST'],'sys_domain').' AND hidden=0');
-						$row2=$GLOBALS['TYPO3_DB']->sql_fetch_row($res2);
-						$domain_id=$row2[0];
+						$res2 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+							'uid',
+							'sys_domain',
+							'domainName=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+								$_SERVER['HTTP_HOST'],
+								'sys_domain'
+							) . ' AND hidden=0'
+						);
+						$row2 = $GLOBALS['TYPO3_DB']->sql_fetch_row($res2);
+						$domain_id = $row2[0];
 					}
-					if($row['domain_id']==$domain_id){
-						$specific=true;
-						if($prio[$row['mode']]>$prio[$redirect['mode']]) $redirect=$row;
+					if ($row['domain_id'] == $domain_id) {
+						$specific = true;
+						if ($prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
 					}
-				}else{
+				} else {
 					// All Domains
-					if(!$specific && $prio[$row['mode']]>$prio[$redirect['mode']]) $redirect=$row;
+					if (!$specific && $prio[$row['mode']] > $prio[$redirect['mode']]) $redirect = $row;
 				}
 			}
 		}
 
 		// Do redirect
-		if($redirect){
+		if ($redirect) {
 			// Update statistics
 			$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
 				'tx_odsredirects_redirects',
-				'uid='.$redirect['uid'],
+				'uid=' . $redirect['uid'],
 				array(
 					'counter' => 'counter+1',
 					'tstamp' => time(),
-					'last_referer' => t3lib_div::getIndpEnv('HTTP_REFERER')
+					'last_referer' => t3lib_div::getIndpEnv('HTTP_REFERER'),
 				),
 				array('counter')
 			);
 
 			// Build destination URL
-			if($redirect['mode']==4) $redirect['destination']=preg_replace('/'.$redirect['url'].'/i',$redirect['destination'],$url);
-			$destination=$this->getLink($redirect['destination'],$_SERVER['HTTP_HOST'].'/'.$url);
+			if ($redirect['mode'] == 4) $redirect['destination'] =
+				preg_replace('/' . $redirect['url'] . '/i', $redirect['destination'], $url);
+			$destination = $this->getLink($redirect['destination'], $_SERVER['HTTP_HOST'] . '/' . $url);
 
 			// Append trailing url
-			if($redirect['append']){
-				$append=substr($url,strlen($redirect['url']));
+			if ($redirect['append']) {
+				$append = substr($url, strlen($redirect['url']));
 				// Replace ? by & if query parts appended to non speaking url
-				if(strpos($destination,'?') && substr($append,0,1)=='?') $append='&'.substr($append,1);
-				$destination.=$append;
+				if (strpos($destination, '?') && substr($append, 0, 1) == '?') $append = '&' . substr($append, 1);
+				$destination .= $append;
 			}
 
 			// Redirect
 			if ($redirect['has_moved']) {
 				header('HTTP/1.1 301 Moved Permanently');
 			}
-			header('Location: '.t3lib_div::locationHeaderUrl($destination));
+			header('Location: ' . t3lib_div::locationHeaderUrl($destination));
 			header('X-Note: Redirect by ods_redirects');
 			header('Connection: close');
 			exit();
 		}
 	}
 
-	function getLink($destination,$source=''){
-		// $destination='test@example.com'; // email
-		// $destination='http://example.com/test.html'; // URL
-		// $destination='example.com'; // URL without http://
-		// $destination='example.com/test.html'; // URL without http://
-		// $destination='/test.html'; // path
-		// $destination='test/test.html'; // path
-		// $destination='123'; // page id
-		// $destination='test'; // alias
-		if(strpos($destination,'@')){
-			// email
-			return 'mailto:'.$destination;
-		}elseif(strpos($destination,'//')){
-			// URL
-			return $destination;
-		}elseif((strpos($destination,'.') && strpos($destination,'/')===false) || (strpos($destination,'.')<strpos($destination,'/'))){
-			// URL without http://
-			return 'http://'.$destination;
-		}elseif(strpos($destination,'/')!==false){
-			// path
-			return $destination;
-		}elseif(is_numeric($destination)){
-			// page id
-			// language detection
-			$L=$this->languageDetection($source);
-			// build URL
-			$url=$this->buildURL($destination,$L);
-			if(!$url) $url='index.php?id='.$destination.($L===false ? '' : '&L='.$L);
-			return $url;
-		}else{
-			// alias
-			return 'index.php?id='.$destination;
-		}
+	/**
+	 * @param string $destination
+	 * @param string $source
+	 * @return string
+     */
+	function getLink($destination, $source = '')
+	{
+		$L = $this->languageDetection($source);
+
+		return $this->buildURL($destination, $L ? array('L' => $L) : array());
 	}
 
-	function languageDetection($source){
-		$conf=unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ods_redirects']);
+	/**
+	 * @param string $source
+	 * @return bool|int
+     */
+	function languageDetection($source)
+	{
+		$conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ods_redirects']);
 
 		// Language from L
-		$L=is_numeric(t3lib_div::_GP('L')) ? intval(t3lib_div::_GP('L')) : false;
+		$L = is_numeric(t3lib_div::_GP('L')) ? intval(t3lib_div::_GP('L')) : false;
 
 		// Language from speaking URL
-		if(!$L && $conf['lang_detect'] && $source){
-//			parse_str($conf['lang_detect'],$lang_detect); // not work with "."
-			$lang_detect=array();
-			foreach(explode(';',$conf['lang_detect']) as $pair){
-				$parts=explode('=',$pair);
-				$lang_detect[$parts[0]]=$parts[1];
+		if (!$L && $conf['lang_detect'] && $source) {
+			$lang_detect = array();
+			foreach (explode(';', $conf['lang_detect']) as $pair) {
+				$parts = explode('=', $pair);
+				$lang_detect[$parts[0]] = $parts[1];
 			}
-			foreach($lang_detect as $str=>$id){
-				if(strpos($source,strval($str))!==false) $L=intval($id);
+			foreach ($lang_detect as $str => $id) {
+				if (strpos($source, strval($str)) !== false) $L = intval($id);
 			}
 		}
+
 		return $L;
 	}
 
-	function buildURL($id,$L=false){
-		if($id){
+	/**
+	 * @param string $id
+	 * @param bool $L
+	 * @return string
+     */
+	function buildURL($id, $L = false)
+	{
+		if ($id) {
 			$GLOBALS['TSFE']->determineId();
 			$GLOBALS['TSFE']->getCompressedTCarray();
 			$GLOBALS['TSFE']->initTemplate();
@@ -171,13 +176,13 @@ class tx_odsredirects {
 
 			$cObj = t3lib_div::makeInstance('tslib_cObj');
 			$cObj->start(array());
-			$url = $cObj->getTypoLink_URL($id, $L ? array('L'=>$L) : array());
+			$url = $cObj->getTypoLink_URL($id, $L ? array('L' => $L) : array());
+
 			return $url;
 		}
 	}
 }
 
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php'])	{
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php']) {
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/class.tx_odsredirects.php']);
 }
-?>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,37 +11,32 @@
 ########################################################################
 
 $EM_CONF[$_EXTKEY] = array(
-	'title' => 'Static redirects',
-	'description' => 'Simply manage (permanent 301) redirects in the list view. The extension supports multidomain sites, count the redirect usage and shows the last referer. UPDATE! imports the records from realurl.',
-	'category' => 'fe',
-	'author' => 'Robert Heel, Andreas Heling',
-	'author_email' => 'aheling@1drop.de',
-	'shy' => '',
-	'dependencies' => '',
-	'conflicts' => '',
-	'priority' => '',
-	'module' => '',
-	'state' => 'stable',
-	'internal' => '',
-	'uploadfolder' => 0,
-	'createDirs' => '',
-	'modify_tables' => '',
-	'clearCacheOnLoad' => 0,
-	'lockType' => '',
-	'author_company' => 'http://www.1drop.de/',
-	'version' => '1.2.0',
-	'constraints' => array(
-		'depends' => array(
-			'typo3' => '4.5.0-6.2.99',
-		),
-		'conflicts' => array(
-		),
-		'suggests' => array(
-		),
-	),
-	'_md5_values_when_last_written' => 'a:13:{s:9:"ChangeLog";s:4:"a5de";s:20:"class.ext_update.php";s:4:"fb83";s:25:"class.tx_odsredirects.php";s:4:"70ea";s:21:"ext_conf_template.txt";s:4:"a385";s:12:"ext_icon.gif";s:4:"1cfa";s:17:"ext_localconf.php";s:4:"34bb";s:14:"ext_tables.php";s:4:"ff8f";s:14:"ext_tables.sql";s:4:"b74e";s:34:"icon_tx_odsredirects_redirects.png";s:4:"55cb";s:16:"locallang_db.xml";s:4:"560a";s:7:"tca.php";s:4:"81d8";s:14:"doc/manual.sxw";s:4:"b026";s:33:"pi1/class.tx_odsredirects_pi1.php";s:4:"be00";}',
-	'suggests' => array(
-	),
+    'title'                         => 'Static redirects',
+    'description'                   => 'Simply manage (permanent 301) redirects in the list view. The extension supports multidomain sites, count the redirect usage and shows the last referer. UPDATE! imports the records from realurl.',
+    'category'                      => 'fe',
+    'author'                        => 'Robert Heel, Andreas Heling',
+    'author_email'                  => 'aheling@1drop.de',
+    'shy'                           => '',
+    'dependencies'                  => '',
+    'conflicts'                     => '',
+    'priority'                      => '',
+    'module'                        => '',
+    'state'                         => 'stable',
+    'internal'                      => '',
+    'uploadfolder'                  => 0,
+    'createDirs'                    => '',
+    'modify_tables'                 => '',
+    'clearCacheOnLoad'              => 0,
+    'lockType'                      => '',
+    'author_company'                => 'http://www.1drop.de/',
+    'version'                       => '1.2.0',
+    'constraints'                   => array(
+        'depends'   => array(
+            'typo3' => '4.5.0-6.2.99',
+        ),
+        'conflicts' => array(),
+        'suggests'  => array(),
+    ),
+    '_md5_values_when_last_written' => 'a:13:{s:9:"ChangeLog";s:4:"a5de";s:20:"class.ext_update.php";s:4:"fb83";s:25:"class.tx_odsredirects.php";s:4:"70ea";s:21:"ext_conf_template.txt";s:4:"a385";s:12:"ext_icon.gif";s:4:"1cfa";s:17:"ext_localconf.php";s:4:"34bb";s:14:"ext_tables.php";s:4:"ff8f";s:14:"ext_tables.sql";s:4:"b74e";s:34:"icon_tx_odsredirects_redirects.png";s:4:"55cb";s:16:"locallang_db.xml";s:4:"560a";s:7:"tca.php";s:4:"81d8";s:14:"doc/manual.sxw";s:4:"b026";s:33:"pi1/class.tx_odsredirects_pi1.php";s:4:"be00";}',
+    'suggests'                      => array(),
 );
-
-?>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,10 +1,15 @@
 <?php
-if (!defined ('TYPO3_MODE')) die ('Access denied.');
+if (!defined('TYPO3_MODE')) die ('Access denied.');
 
 // Global redirects
-if(!is_array($TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'])) $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc']=array();
-array_unshift($TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'],'EXT:ods_redirects/class.tx_odsredirects.php:&tx_odsredirects->checkRedirect');
+if (!is_array($TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'])) {
+    $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'] = array();
+}
+
+array_unshift(
+    $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'],
+    'EXT:ods_redirects/class.tx_odsredirects.php:&tx_odsredirects->checkRedirect'
+);
 
 // Plugin redirects
 t3lib_extMgm::addPItoST43($_EXTKEY, 'pi1/class.tx_odsredirects_pi1.php', '_pi1', 'list_type', 0);
-?>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,32 +1,35 @@
 <?php
-if (!defined ('TYPO3_MODE')) die ('Access denied.');
+if (!defined('TYPO3_MODE')) die ('Access denied.');
 
 // Global redirects
 t3lib_extMgm::addToInsertRecords('tx_odsredirects_redirects');
 $TCA['tx_odsredirects_redirects'] = array(
-	'ctrl' => array (
-		'title' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects',
-		'label' => 'url',
-		'tstamp' => 'tstamp',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'default_sortby' => 'ORDER BY url',
-		'rootLevel' => -1,
-		'enablecolumns' => array(
-			'disabled' => 'hidden',
-		),
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile' => t3lib_extMgm::extRelPath($_EXTKEY).'icon_tx_odsredirects_redirects.png',
-	),
+    'ctrl' => array(
+        'title'             => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects',
+        'label'             => 'url',
+        'tstamp'            => 'tstamp',
+        'crdate'            => 'crdate',
+        'cruser_id'         => 'cruser_id',
+        'default_sortby'    => 'ORDER BY url',
+        'rootLevel'         => -1,
+        'enablecolumns'     => array(
+            'disabled' => 'hidden',
+        ),
+        'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY) . 'tca.php',
+        'iconfile'          => t3lib_extMgm::extRelPath($_EXTKEY) . 'icon_tx_odsredirects_redirects.png',
+    ),
 );
 
 // Plugin redirects
 t3lib_div::loadTCA('tt_content');
-$TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_pi1']='header,header_position,header_link,header_layout,date,spaceBefore,spaceAfter,section_frame,layout,select_key,recursive';
+$TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY . '_pi1'] =
+    'header,header_position,header_link,header_layout,date,spaceBefore,spaceAfter,section_frame,layout,select_key,recursive';
 
-t3lib_extMgm::addPlugin(array(
-	'LLL:EXT:ods_redirects/locallang_db.xml:tt_content.list_type_pi1',
-	$_EXTKEY . '_pi1',
-	t3lib_extMgm::extRelPath($_EXTKEY) . 'ext_icon.gif'
-),'list_type');
-?>
+t3lib_extMgm::addPlugin(
+    array(
+        'LLL:EXT:ods_redirects/locallang_db.xml:tt_content.list_type_pi1',
+        $_EXTKEY . '_pi1',
+        t3lib_extMgm::extRelPath($_EXTKEY) . 'ext_icon.gif',
+    ),
+    'list_type'
+);

--- a/pi1/class.tx_odsredirects_pi1.php
+++ b/pi1/class.tx_odsredirects_pi1.php
@@ -1,34 +1,33 @@
 <?php
 /***************************************************************
-*  Copyright notice
-*
-*  (c) 2011 Robert Heel <rheel@1drop.de>
-*  All rights reserved
-*
-*  This script is part of the TYPO3 project. The TYPO3 project is
-*  free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2 of the License, or
-*  (at your option) any later version.
-*
-*  The GNU General Public License can be found at
-*  http://www.gnu.org/copyleft/gpl.html.
-*
-*  This script is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  This copyright notice MUST APPEAR in all copies of the script!
-***************************************************************/
+ *  Copyright notice
+ *
+ *  (c) 2011 Robert Heel <rheel@1drop.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
 /**
  * [CLASS/FUNCTION INDEX of SCRIPT]
  *
  * Hint: use extdeveval to insert/update function index above.
  */
 
-require_once(PATH_tslib.'class.tslib_pibase.php');
-
+require_once(PATH_tslib . 'class.tslib_pibase.php');
 
 /**
  * Plugin 'Redirect' for the 'ods_redirects' extension.
@@ -37,46 +36,70 @@ require_once(PATH_tslib.'class.tslib_pibase.php');
  * @package    TYPO3
  * @subpackage    tx_odsredirects
  */
-class tx_odsredirects_pi1 extends tslib_pibase {
-	var $prefixId      = 'tx_odsredirects_pi1';        // Same as class name
-	var $scriptRelPath = 'pi1/class.tx_odsredirects_pi1.php';    // Path to this script relative to the extension dir.
-	var $extKey        = 'ods_redirects';    // The extension key.
-	
-	/**
-	* The main method of the PlugIn
-	*
-	* @param    string        $content: The PlugIn content
-	* @param    array        $conf: The PlugIn configuration
-	* @return    The content that is displayed on the website
-	*/
-	function main($content, $conf) {
-		$this->conf = $conf;
-/*		$this->pi_setPiVarDefaults();
-		$this->pi_loadLL();*/
-		$this->pi_USER_INT_obj = 1;    // Configuring so caching is not expected. This value means that no cHash params are ever set. We do this, because it's a USER_INT object!
+class tx_odsredirects_pi1 extends tslib_pibase
+{
+    /**
+     * Same as class name
+     *
+     * @var string
+     */
+    var $prefixId = 'tx_odsredirects_pi1';
 
-		if($this->cObj->data['pages']){
-			$destination=$this->getLink($this->cObj->data['pages'],$GLOBALS['TSFE']->sys_language_uid);
+    /**
+     * Path to this script relative to the extension dir.
+     *
+     * @var string
+     */
+    var $scriptRelPath = 'pi1/class.tx_odsredirects_pi1.php';
 
-			// Redirect
-	// 		if ($redirect['has_moved']) {
-				header('HTTP/1.1 301 Moved Permanently');
-	// 		}
-			header('Location: '.t3lib_div::locationHeaderUrl($destination));
-			header('X-Note: Redirect by ods_redirects');
-			header('Connection: close');
-			exit();
-		}
-	}
+    /**
+     * The extension key.
+     *
+     * @var string
+     */
+    var $extKey = 'ods_redirects';
 
-	function getLink($id,$L=false){
-		return $this->cObj->getTypoLink_URL($id, $L ? array('L'=>$L) : array());
-	}
+    /**
+     * The main method of the PlugIn
+     *
+     * @param string $content The PlugIn content
+     * @param array $conf The PlugIn configuration
+     * @return The content that is displayed on the website
+     */
+    function main($content, $conf)
+    {
+        $this->conf = $conf;
+
+        // Configuring so caching is not expected. This value means that no cHash params are ever set. We do this, because it's a USER_INT object!
+        $this->pi_USER_INT_obj = 1;
+
+        if ($this->cObj->data['pages']) {
+            $destination = $this->getLink($this->cObj->data['pages'], $GLOBALS['TSFE']->sys_language_uid);
+
+            // Redirect
+            if ($redirect['has_moved']) {
+                header('HTTP/1.1 301 Moved Permanently');
+            } else {
+                header('HTTP/1.1 302 Moved Temporarily');
+            }
+            header('Location: ' . t3lib_div::locationHeaderUrl($destination));
+            header('Connection: close');
+            exit();
+        }
+    }
+
+    /**
+     * @param string $id
+     * @param bool $L
+     * @return mixed
+     */
+    function getLink($id, $L = false)
+    {
+        return $this->cObj->getTypoLink_URL($id, $L ? array('L' => $L) : array());
+    }
 }
 
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/pi1/class.tx_odsredirects_pi1.php'])    {
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/pi1/class.tx_odsredirects_pi1.php']) {
     include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/ods_redirects/pi1/class.tx_odsredirects_pi1.php']);
 }
-?>

--- a/tca.php
+++ b/tca.php
@@ -56,8 +56,8 @@ $TCA['tx_odsredirects_redirects'] = array (
 			)
 		),
 		'destination' => array (
-			'exclude' => 0,
-			'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.destination',
+        'exclude' => 0,
+            'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.destination',
 			'config' => array (
 				'type'     => 'input',
 				'size'     => 15,

--- a/tca.php
+++ b/tca.php
@@ -41,7 +41,7 @@ $TCA['tx_odsredirects_redirects'] = array (
 		),
 		'mode' => array (
 			'exclude' => 0,
-			'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.mode',		
+			'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.mode',
 			'config' => array (
 				'type' => 'select',
 				'items' => array (
@@ -57,7 +57,7 @@ $TCA['tx_odsredirects_redirects'] = array (
 		),
 		'destination' => array (
 			'exclude' => 0,
-			'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.destination',		
+			'label' => 'LLL:EXT:ods_redirects/locallang_db.xml:tx_odsredirects_redirects.destination',
 			'config' => array (
 				'type'     => 'input',
 				'size'     => 15,
@@ -115,4 +115,3 @@ $TCA['tx_odsredirects_redirects'] = array (
 		'1' => array('showitem' => 'append, has_moved')
 	)
 );
-?>


### PR DESCRIPTION
This PR fixes the way links are generated during the redirect. Previous version did not support the "custom link parameter" setting by Typo3. When "permanent" is not checked, the extension will now emit a 302 "Temporarily moved" redirect header (previously always was 301).

Further more many smaller changes were made to clean up the code (removing comments, correct indenation, phpDoc comments).

Feel free to merge, used in production.
